### PR TITLE
Fix Puli Path for Composer Package Example

### DIFF
--- a/repository/getting-started.rst
+++ b/repository/getting-started.rst
@@ -215,7 +215,7 @@ all files found through these |path mappings|. Let's print the contents of the
 
         public function printResources()
         {
-            echo $this->repo->get('/app/views/index.html.twig')->getBody();
+            echo $this->repo->get('/batman/blog/views/index.html.twig')->getBody();
         }
     }
 


### PR DESCRIPTION
The docs say to execute the following command:

```
$ php puli.phar map /batman/blog res
```

So the right Puli Path for the template is:
`/batman/blog/views/index.html.twig`
